### PR TITLE
Add Forward / Back as Three Finger Gesture -> Wip/show desktop algorithms

### DIFF
--- a/extension/common/settings.ts
+++ b/extension/common/settings.ts
@@ -6,12 +6,16 @@ export enum PinchGestureType {
     SHOW_DESKTOP = 1,
 }
 
+export enum SwipeGestureType {
+    SWITCH_WINDOWS = 0,
+    FORWARD_BACK = 1,
+}
+
 export type BooleanSettingsKeys =
     'default-session-workspace' |
     'default-overview' |
     'allow-minimize-window' |
     'follow-natural-scroll' |
-    'enable-alttab-gesture' |
     'enable-window-manipulation-gesture' |
     'default-overview-gesture-direction'
     ;
@@ -26,7 +30,8 @@ export type DoubleSettingsKeys =
 
 export type EnumSettingsKeys =
     'pinch-3-finger-gesture' |
-    'pinch-4-finger-gesture'
+    'pinch-4-finger-gesture' |
+    'swipe-3-finger-horizontal-gesture'
     ;
 
 
@@ -51,7 +56,8 @@ type Enum_Functions<K extends EnumSettingsKeys, T> = {
 }
 
 type SettingsEnumFunctions =
-    Enum_Functions<'pinch-3-finger-gesture' | 'pinch-4-finger-gesture', PinchGestureType>
+    Enum_Functions<'pinch-3-finger-gesture' | 'pinch-4-finger-gesture', PinchGestureType> &
+    Enum_Functions<'swipe-3-finger-horizontal-gesture', SwipeGestureType>
     ;
 
 export type GioSettings =

--- a/extension/extension.ts
+++ b/extension/extension.ts
@@ -1,9 +1,10 @@
 import GLib from '@gi-types/glib2';
 import { imports } from 'gnome-shell';
-import { AllSettingsKeys, GioSettings, PinchGestureType } from './common/settings';
+import { AllSettingsKeys, GioSettings, PinchGestureType, SwipeGestureType } from './common/settings';
 import * as Constants from './constants';
 import { AltTabConstants, ExtSettings, TouchpadConstants } from './constants';
 import { AltTabGestureExtension } from './src/altTab';
+import { ForwardBackGestureExtension } from './src/forwardBack';
 import { GestureExtension } from './src/gestures';
 import { OverviewRoundTripGestureExtension } from './src/overviewRoundTrip';
 import { ShowDesktopExtension } from './src/pinchGestures/showDesktop';
@@ -72,8 +73,17 @@ class Extension {
 		if (this.settings === undefined)
 			return;
 
-		if (this.settings.get_boolean('enable-alttab-gesture'))
-			this._extensions.push(new AltTabGestureExtension());
+		switch (this.settings.get_enum('swipe-3-finger-horizontal-gesture'))
+		{
+			case SwipeGestureType.FORWARD_BACK:
+				this._extensions.push(new ForwardBackGestureExtension());
+				break;
+			case SwipeGestureType.SWITCH_WINDOWS:
+				this._extensions.push(new AltTabGestureExtension());
+				break;
+			default:
+				break;
+		}
 
 		this._extensions.push(
 			new OverviewRoundTripGestureExtension(),

--- a/extension/schemas/org.gnome.shell.extensions.gestureImprovements.gschema.xml
+++ b/extension/schemas/org.gnome.shell.extensions.gestureImprovements.gschema.xml
@@ -4,6 +4,10 @@
     <value value='0' nick='NONE' />
     <value value='1' nick='SHOW_DESKTOP' />
   </enum>
+  <enum id='org.gnome.shell.extensions.gestureImprovements.swipe-gestures'>
+    <value value='0' nick='SWITCH_WINDOWS' />
+    <value value='1' nick='FORWARD_BACK' />
+  </enum>
   <schema id="org.gnome.shell.extensions.gestureImprovements" path="/org/gnome/shell/extensions/gestureImprovements/">
     <!-- See also: https://developer.gnome.org/glib/stable/gvariant-format-strings.html -->
     <key name="touchpad-speed-scale" type="d">
@@ -35,10 +39,6 @@
       <default>true</default>
       <description>Default direction for overview navigation</description>
     </key>
-    <key name='enable-alttab-gesture' type='b'>
-      <default>true</default>
-      <description>Enable alttab gesture</description>
-    </key>
     <key name='enable-window-manipulation-gesture' type='b'>
       <default>true</default>
       <description>Enable Window manipulation gesture</description>
@@ -50,6 +50,10 @@
     <key name="pinch-4-finger-gesture" enum="org.gnome.shell.extensions.gestureImprovements.pinch-gestures">
       <default>'NONE'</default>
       <description>Gesture for 4 finger pinch</description>
+    </key>
+    <key name="swipe-3-finger-horizontal-gesture" enum="org.gnome.shell.extensions.gestureImprovements.swipe-gestures">
+      <default>'SWITCH_WINDOWS'</default>
+      <description>Gesture for 3 finger horizontal swipe</description>
     </key>
   </schema>
 </schemalist>

--- a/extension/src/forwardBack.ts
+++ b/extension/src/forwardBack.ts
@@ -1,0 +1,75 @@
+import Clutter from '@gi-types/clutter8';
+import Shell from '@gi-types/shell0';
+import { imports } from 'gnome-shell';
+import { ExtSettings } from '../constants';
+import { TouchpadSwipeGesture } from './swipeTracker';
+
+const Main = imports.ui.main;
+
+export class ForwardBackGestureExtension implements ISubExtension {
+	private _connectHandlers: number[];
+	private _progress = 0;
+	private _touchpadSwipeTracker: typeof TouchpadSwipeGesture.prototype;
+	private _virtualDevice: Clutter.VirtualInputDevice;
+
+	constructor() {
+		this._connectHandlers = [];
+
+		this._touchpadSwipeTracker = new TouchpadSwipeGesture(
+			(ExtSettings.DEFAULT_SESSION_WORKSPACE_GESTURE ? [4] : [3]),
+			Shell.ActionMode.ALL,
+			Clutter.Orientation.HORIZONTAL,
+			false,
+			this._checkAllowedGesture.bind(this),
+		);
+
+		const seat = Clutter.get_default_backend().get_default_seat();
+		this._virtualDevice = seat.create_virtual_device(Clutter.InputDeviceType.KEYBOARD_DEVICE);
+
+	}
+
+	_checkAllowedGesture(): boolean {
+		return Main.actionMode === Shell.ActionMode.NORMAL;
+	}
+
+	apply(): void {
+		this._touchpadSwipeTracker.orientation = Clutter.Orientation.HORIZONTAL;
+		this._connectHandlers.push(this._touchpadSwipeTracker.connect('begin', this._gestureBegin.bind(this)));
+		this._connectHandlers.push(this._touchpadSwipeTracker.connect('update', this._gestureUpdate.bind(this)));
+		this._connectHandlers.push(this._touchpadSwipeTracker.connect('end', this._gestureEnd.bind(this)));
+	}
+
+	destroy(): void {
+		this._connectHandlers.forEach(handle => this._touchpadSwipeTracker.disconnect(handle));
+
+		this._touchpadSwipeTracker.destroy();
+		this._connectHandlers = [];
+	}
+
+	_gestureBegin(): void {
+		this._progress = 0;
+	}
+
+	_gestureUpdate(_gesture: never, _time: never, delta: number, _distance: number): void {
+		this._progress += delta;
+	}
+
+	_gestureEnd(): void {
+		if (this._progress > 0)
+			this._sendKeyEvent(Clutter.KEY_Forward);
+		else
+			this._sendKeyEvent(Clutter.KEY_Back);
+
+		this._reset();
+	}
+
+	private _reset() {
+		this._progress = 0;
+	}
+
+	_sendKeyEvent(...keys: number[]): void {
+		const currentTime = Clutter.get_current_event_time();
+		keys.forEach(key => this._virtualDevice.notify_keyval(currentTime, key, Clutter.KeyState.PRESSED));
+		keys.forEach(key => this._virtualDevice.notify_keyval(currentTime, key, Clutter.KeyState.RELEASED));
+	}
+}

--- a/extension/ui/prefs.ui
+++ b/extension/ui/prefs.ui
@@ -186,7 +186,7 @@ other gesture, if enabled, will be activated using 4-finger gesture.
                           </object>
                         </child>
 
-                        <!-- AltTab Gesture -->
+                        <!-- 3 finger horizontal swipe gesture -->
                         <child>
                           <object class="GtkListBoxRow">
                             <property name="child">
@@ -203,15 +203,16 @@ other gesture, if enabled, will be activated using 4-finger gesture.
                                     <property name="valign">center</property>
                                     <property name="hexpand">1</property>
                                     <property name="xalign">0</property>
-                                    <property name="label" translatable="yes">Window switching</property>
+                                    <property name="label" translatable="yes">3 finger horizontal swipe</property>
                                   </object>
                                 </child>
 
                                 <child>
-                                  <object class="GtkSwitch" id="enable-alttab-gesture">
-                                    <property name="halign">end</property>
-                                    <property name="can-focus">True</property>
-                                    <property name="valign">center</property>
+                                  <object class="GtkComboBoxText" id="swipe-3-finger-horizontal-gesture">
+                                    <items>
+                                      <item translatable="yes" id="0">Switch Windows</item>
+                                      <item translatable="yes" id="1">Forward / Back</item>
+                                    </items>
                                   </object>
                                 </child>
 


### PR DESCRIPTION
* Add Forward / Back as Three Finger Horizontal Swipe
* In settings user can customize, whether he wants Alt+Tab or Forward / Back

Fixes #23
Like #39, but resolves conflicts with `Wip/show desktop algorithms`