### PR TITLE
overviewRoundTrip: Add option to set navigation states for overview gesture

### DIFF
--- a/extension/common/prefs.ts
+++ b/extension/common/prefs.ts
@@ -37,9 +37,11 @@ function bind_boolean_value(key: BooleanSettingsKeys, settings: GioSettings, bui
  */
 function bind_combo_box(key: EnumSettingsKeys, settings: GioSettings, builder: GtkBuilder) {
 	const comboRow = builder.get_object<Adw.ComboRow>(key);
-	comboRow.set_selected(settings.get_enum(key));
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	const enum_key = key as any;
+	comboRow.set_selected(settings.get_enum(enum_key));
 	comboRow.connect('notify::selected', () => {
-		settings.set_enum(key, comboRow.selected);
+		settings.set_enum(enum_key, comboRow.selected);
 	});
 }
 
@@ -86,6 +88,7 @@ function bindPrefsSettings(builder: GtkBuilder, settings: Gio.Settings) {
 
 	bind_combo_box('pinch-3-finger-gesture', settings, builder);
 	bind_combo_box('pinch-4-finger-gesture', settings, builder);
+	bind_combo_box('overview-navifation-states', settings, builder);
 }
 
 function loadCssProvider(styleManager: Adw.StyleManager,uiDir: string) {

--- a/extension/common/settings.ts
+++ b/extension/common/settings.ts
@@ -9,6 +9,13 @@ export enum PinchGestureType {
     CLOSE_DOCUMENT = 3,
 }
 
+// define enum
+export enum OverviewNavigationState {
+    CYCLIC = 0,
+    GNOME = 1,
+    WINDOW_PICKER_ONLY = 2,
+}
+
 export enum ForwardBackKeyBinds {
     Default = 0,
     'Forward/Backward' = 1,
@@ -40,7 +47,8 @@ export type DoubleSettingsKeys =
 
 export type EnumSettingsKeys =
     'pinch-3-finger-gesture' |
-    'pinch-4-finger-gesture'
+    'pinch-4-finger-gesture' |
+    'overview-navifation-states'
     ;
 
 export type MiscSettingsKeys = 
@@ -73,7 +81,8 @@ type Enum_Functions<K extends EnumSettingsKeys, T> = {
 }
 
 type SettingsEnumFunctions =
-    Enum_Functions<'pinch-3-finger-gesture' | 'pinch-4-finger-gesture', PinchGestureType>
+    Enum_Functions<'pinch-3-finger-gesture' | 'pinch-4-finger-gesture', PinchGestureType> &
+    Enum_Functions<'overview-navifation-states', OverviewNavigationState>
     ;
 
 type Misc_Functions<K extends MiscSettingsKeys, T extends string> = {

--- a/extension/extension.ts
+++ b/extension/extension.ts
@@ -84,7 +84,7 @@ class Extension {
 		}
 
 		this._extensions.push(
-			new OverviewRoundTripGestureExtension(),
+			new OverviewRoundTripGestureExtension(this.settings.get_enum('overview-navifation-states')),
 			new GestureExtension(),
 		);
 

--- a/extension/schemas/org.gnome.shell.extensions.gestureImprovements.gschema.xml
+++ b/extension/schemas/org.gnome.shell.extensions.gestureImprovements.gschema.xml
@@ -6,6 +6,12 @@
     <value value='2' nick='CLOSE_WINDOW' />
     <value value='3' nick='CLOSE_DOCUMENT' />
   </enum>
+  <!--  -->
+  <enum id='org.gnome.shell.extensions.gestureImprovements.overview-navigation-states'>
+    <value value='0' nick='CYCLIC' />
+    <value value='1' nick='GNOME' />
+    <value value='2' nick='WINDOW_PICKER_ONLY' />
+  </enum>
   <schema id="org.gnome.shell.extensions.gestureImprovements" path="/org/gnome/shell/extensions/gestureImprovements/">
     <!-- See also: https://docs.gtk.org/glib/gvariant-format-strings.html -->
     <key name="touchpad-speed-scale" type="d">
@@ -58,6 +64,10 @@
     </key>
     <key name="pinch-4-finger-gesture" enum="org.gnome.shell.extensions.gestureImprovements.pinch-gestures">
       <default>'SHOW_DESKTOP'</default>
+      <description>Gesture for 4 finger pinch</description>
+    </key>
+    <key name="overview-navifation-states" enum="org.gnome.shell.extensions.gestureImprovements.overview-navigation-states">
+      <default>'CYCLIC'</default>
       <description>Gesture for 4 finger pinch</description>
     </key>
     <!-- 

--- a/extension/src/overviewRoundTrip.ts
+++ b/extension/src/overviewRoundTrip.ts
@@ -1,6 +1,7 @@
 import Clutter from '@gi-types/clutter';
 import Shell from '@gi-types/shell';
 import { global, imports } from 'gnome-shell';
+import { OverviewNavigationState } from '../common/settings';
 import { ExtSettings, OverviewControlsState } from '../constants';
 import { createSwipeTracker } from './swipeTracker';
 
@@ -24,7 +25,10 @@ export class OverviewRoundTripGestureExtension implements ISubExtension {
 	private _connectors: number[];
 	private _shownEventId = 0;
 	private _hiddenEventId = 0;
-	constructor() {
+	private _navigationStates: OverviewNavigationState;
+
+	constructor(navigationStates: OverviewNavigationState) {
+		this._navigationStates = navigationStates;
 		this._overviewControls = Main.overview._overview._controls;
 		this._stateAdjustment = this._overviewControls._stateAdjustment;
 		this._oldGetStateTransitionParams = this._overviewControls._stateAdjustment.getStateTransitionParams;
@@ -98,12 +102,10 @@ export class OverviewRoundTripGestureExtension implements ISubExtension {
 
 	_gestureBegin(tracker: typeof SwipeTracker.prototype): void {
 		const _tracker = {
-			confirmSwipe: (distance: number, snapPoints: number[], currentProgress: number, cancelProgress: number) => {
-				snapPoints.unshift(OverviewControlsState.APP_GRID_P);
-				snapPoints.push(OverviewControlsState.HIDDEN_N);
+			confirmSwipe: (distance: number, _snapPoints: number[], currentProgress: number, cancelProgress: number) => {
 				tracker.confirmSwipe(
 					distance,
-					snapPoints,
+					this._getGestureSnapPoints(),
 					currentProgress,
 					cancelProgress,
 				);
@@ -170,5 +172,29 @@ export class OverviewRoundTripGestureExtension implements ISubExtension {
 		}
 
 		return progress;
+	}
+
+	private _getGestureSnapPoints(): number[] {
+		switch (this._navigationStates) {
+			case OverviewNavigationState.CYCLIC:
+				return [
+					OverviewControlsState.APP_GRID_P,
+					OverviewControlsState.HIDDEN,
+					OverviewControlsState.WINDOW_PICKER,
+					OverviewControlsState.APP_GRID,
+					OverviewControlsState.HIDDEN_N,
+				];
+			case OverviewNavigationState.GNOME:
+				return [
+					OverviewControlsState.HIDDEN,
+					OverviewControlsState.WINDOW_PICKER,
+					OverviewControlsState.APP_GRID,
+				];
+			case OverviewNavigationState.WINDOW_PICKER_ONLY:
+				return [
+					OverviewControlsState.HIDDEN,
+					OverviewControlsState.WINDOW_PICKER,
+				];
+		}
 	}
 }

--- a/extension/ui/customizations.ui
+++ b/extension/ui/customizations.ui
@@ -3,6 +3,14 @@
   <requires lib="gtk" version="4.0" />
   <requires lib="libadwaita" version="1.0" />
 
+  <object class="GtkStringList" id="overview_navigation_states_model">
+    <items>
+      <item translatable="yes">Cyclic</item>
+      <item translatable="yes">GNOME</item>
+      <item translatable="yes">Overview only</item>
+    </items>
+  </object>
+
   <object class="AdwPreferencesPage" id="customizations_page">
     <property name="title">Misc</property>
     <property name="icon-name">emblem-system-symbolic</property>
@@ -76,6 +84,14 @@
                 <property name="active">True</property>
               </object>
             </child>
+          </object>
+        </child>
+
+        <!-- Overview navigation states -->
+        <child>
+          <object class="AdwComboRow" id="overview-navifation-states">
+            <property name="title" translatable="yes">Overview navigation states</property>
+            <property name="model">overview_navigation_states_model</property>
           </object>
         </child>
 


### PR DESCRIPTION
This allows cyclic overview navigation as well as gnome-style navigation.
It also adds option for only desktop<->windowPicker transitions

Closes #90 