### PR TITLE
[Draft]: New UI and 4 finger App navigation vertical motion gestures

### DIFF
--- a/extension/common/settings.ts
+++ b/extension/common/settings.ts
@@ -1,7 +1,21 @@
 import Gio from '@gi-types/gio2';
 import GLib from '@gi-types/glib2';
 
-// define enum
+// define enum for Horizontal motion Gesture
+export enum SwipeHorizontalGestureType {
+    WINDOW_SWITCHING = 0,
+    APP_NAVIGATION = 1,
+    WORKSPACE_SWITCHING = 2
+}
+
+// define enum for Vertical motion Gestures
+export enum SwipeVerticalGestureType {
+    OVERVIEW_NAVIGATION = 0,
+    APP_NAVIGATION = 1,
+    WINDOW_MANIPULATION = 2 
+}
+
+// define enum for Pinch Gesture
 export enum PinchGestureType {
     NONE = 0,
     SHOW_DESKTOP = 1,
@@ -26,13 +40,13 @@ export enum ForwardBackKeyBinds {
 }
 
 export type BooleanSettingsKeys =
-    'default-session-workspace' |
-    'default-overview' |
-    'allow-minimize-window' |
+    // 'default-session-workspace' |
+    // 'default-overview' |
+    // 'allow-minimize-window' |
+    // 'enable-window-manipulation-gesture' |
     'follow-natural-scroll' |
     'enable-alttab-gesture' |
     'enable-forward-back-gesture' |
-    'enable-window-manipulation-gesture' |
     'default-overview-gesture-direction'
     ;
 
@@ -46,9 +60,13 @@ export type DoubleSettingsKeys =
     ;
 
 export type EnumSettingsKeys =
+    'swipe-horizontal-3-finger-gesture' |
+    'swipe-vertical-3-finger-gesture' |
     'pinch-3-finger-gesture' |
+    'swipe-horizontal-4-finger-gesture' |
+    'swipe-vertical-4-finger-gesture' |
     'pinch-4-finger-gesture' |
-    'overview-navifation-states'
+    'overview-navigation-states'
     ;
 
 export type MiscSettingsKeys = 
@@ -81,8 +99,10 @@ type Enum_Functions<K extends EnumSettingsKeys, T> = {
 }
 
 type SettingsEnumFunctions =
+    Enum_Functions<'swipe-horizontal-3-finger-gesture' | 'swipe-horizontal-4-finger-gesture', SwipeHorizontalGestureType> &
+    Enum_Functions<'swipe-vertical-3-finger-gesture' | 'swipe-vertical-4-finger-gesture', SwipeVerticalGestureType> &
     Enum_Functions<'pinch-3-finger-gesture' | 'pinch-4-finger-gesture', PinchGestureType> &
-    Enum_Functions<'overview-navifation-states', OverviewNavigationState>
+    Enum_Functions<'overview-navigation-states', OverviewNavigationState>
     ;
 
 type Misc_Functions<K extends MiscSettingsKeys, T extends string> = {

--- a/extension/constants.ts
+++ b/extension/constants.ts
@@ -29,10 +29,21 @@ export const OverviewControlsState = {
 	HIDDEN_N: 3,
 };
 
+// export const ExtSettings = {
+// 	DEFAULT_SESSION_WORKSPACE_GESTURE: false,
+// 	DEFAULT_OVERVIEW_GESTURE: false,
+// 	ALLOW_MINIMIZE_WINDOW: false,
+// 	FOLLOW_NATURAL_SCROLL: true,
+// 	APP_GESTURES: false,
+// 	DEFAULT_OVERVIEW_GESTURE_DIRECTION: true,
+// };
+
 export const ExtSettings = {
-	DEFAULT_SESSION_WORKSPACE_GESTURE: false,
-	DEFAULT_OVERVIEW_GESTURE: false,
+	// DEFAULT_SESSION_WORKSPACE_GESTURE: false,
+	// DEFAULT_OVERVIEW_GESTURE: false,  // TODO: remove
 	ALLOW_MINIMIZE_WINDOW: false,
+	
+
 	FOLLOW_NATURAL_SCROLL: true,
 	APP_GESTURES: false,
 	DEFAULT_OVERVIEW_GESTURE_DIRECTION: true,

--- a/extension/extension.ts
+++ b/extension/extension.ts
@@ -1,15 +1,12 @@
+import Clutter from '@gi-types/clutter';
 import GLib from '@gi-types/glib2';
 import { imports } from 'gnome-shell';
-import { AllSettingsKeys, GioSettings, PinchGestureType } from './common/settings';
+import { AllSettingsKeys, GioSettings, PinchGestureType, SwipeHorizontalGestureType, SwipeVerticalGestureType } from './common/settings';
 import * as Constants from './constants';
+import { SwipeGestureInfo, SwipeGestureToExtensionMapper } from './src/gestures';
 import { AltTabConstants, ExtSettings, TouchpadConstants } from './constants';
-import { AltTabGestureExtension } from './src/altTab';
-import { ForwardBackGestureExtension } from './src/forwardBack';
-import { GestureExtension } from './src/gestures';
-import { OverviewRoundTripGestureExtension } from './src/overviewRoundTrip';
 import { CloseWindowExtension } from './src/pinchGestures/closeWindow';
 import { ShowDesktopExtension } from './src/pinchGestures/showDesktop';
-import { SnapWindowExtension } from './src/snapWindow';
 import * as DBusUtils from './src/utils/dbus';
 import * as VKeyboard from './src/utils/keyboard';
 
@@ -73,23 +70,12 @@ class Extension {
 		this._initializeSettings();
 		this._extensions = [];
 		if (this.settings === undefined)
-			return;
-
-		if (this.settings.get_boolean('enable-alttab-gesture'))
-			this._extensions.push(new AltTabGestureExtension());
+		return;
 		
-		if (this.settings.get_boolean('enable-forward-back-gesture')) {
-			const appForwardBackKeyBinds = this.settings.get_value('forward-back-application-keyboard-shortcuts').deepUnpack();
-			this._extensions.push(new ForwardBackGestureExtension(appForwardBackKeyBinds));
-		}
-
-		this._extensions.push(
-			new OverviewRoundTripGestureExtension(this.settings.get_enum('overview-navifation-states')),
-			new GestureExtension(),
-		);
-
-		if (this.settings.get_boolean('enable-window-manipulation-gesture'))
-			this._extensions.push(new SnapWindowExtension());
+		if (this.settings.get_boolean('enable-alttab-gesture'))
+		// this._extensions.push(new AltTabGestureExtension());
+		
+		this._setSwipeGestures()
 
 		// pinch to show desktop
 		const pinchToFingersMap = this._getPinchGestureTypeAndFingers();
@@ -119,17 +105,57 @@ class Extension {
 
 	_initializeSettings() {
 		if (this.settings) {
-			ExtSettings.DEFAULT_SESSION_WORKSPACE_GESTURE = this.settings.get_boolean('default-session-workspace');
-			ExtSettings.DEFAULT_OVERVIEW_GESTURE = this.settings.get_boolean('default-overview');
-			ExtSettings.ALLOW_MINIMIZE_WINDOW = this.settings.get_boolean('allow-minimize-window');
+			// TODO: fix this somewhere, somehow
+			// ExtSettings.ALLOW_MINIMIZE_WINDOW = this.settings.get_boolean('allow-minimize-window');
+			
 			ExtSettings.FOLLOW_NATURAL_SCROLL = this.settings.get_boolean('follow-natural-scroll');
 			ExtSettings.DEFAULT_OVERVIEW_GESTURE_DIRECTION = this.settings.get_boolean('default-overview-gesture-direction');
 			ExtSettings.APP_GESTURES = this.settings.get_boolean('enable-forward-back-gesture');
+
 
 			TouchpadConstants.SWIPE_MULTIPLIER = Constants.TouchpadConstants.DEFAULT_SWIPE_MULTIPLIER * this.settings.get_double('touchpad-speed-scale');
 			TouchpadConstants.PINCH_MULTIPLIER = Constants.TouchpadConstants.DEFAULT_PINCH_MULTIPLIER * this.settings.get_double('touchpad-pinch-speed');
 			AltTabConstants.DELAY_DURATION = this.settings.get_int('alttab-delay');
 			TouchpadConstants.HOLD_SWIPE_DELAY_DURATION = this.settings.get_int('hold-swipe-delay-duration');
+		}
+	}
+
+	private _setSwipeGestures() {
+		if (this.settings)	{
+			const swipeHorizontal3FingerGesture = this.settings.get_enum('swipe-horizontal-3-finger-gesture');
+			const swipeVertical3FingerGesture = this.settings.get_enum('swipe-vertical-3-finger-gesture');
+			const swipeHorizontal4FingerGesture = this.settings.get_enum('swipe-horizontal-4-finger-gesture');
+			const swipeVertical4FingerGesture = this.settings.get_enum('swipe-vertical-4-finger-gesture');
+			
+			const swipeGestureToExtension = new SwipeGestureToExtensionMapper(this.settings)
+
+			const swipeHorizontal3FingerGestureInfo = new SwipeGestureInfo(
+				Clutter.Orientation.HORIZONTAL,
+				[3], swipeHorizontal3FingerGesture
+			)
+			const extension_1 = swipeGestureToExtension.get_extension(swipeHorizontal3FingerGestureInfo)
+
+			const swipeVertical3FingerGestureInfo = new SwipeGestureInfo(
+				Clutter.Orientation.VERTICAL,
+				[3], swipeVertical3FingerGesture
+			)
+			const extension_2 = swipeGestureToExtension.get_extension(swipeVertical3FingerGestureInfo)
+			
+			const swipeHorizontal4FingerGestureInfo = new SwipeGestureInfo(
+				Clutter.Orientation.HORIZONTAL,
+				[4], swipeHorizontal4FingerGesture
+			)
+			const extension_3 = swipeGestureToExtension.get_extension(swipeHorizontal4FingerGestureInfo)
+
+			const swipeVertical4FingerGestureInfo = new SwipeGestureInfo(
+				Clutter.Orientation.VERTICAL,
+				[4], swipeVertical4FingerGesture
+			)
+			const extension_4 = swipeGestureToExtension.get_extension(swipeVertical4FingerGestureInfo)
+			
+			this._extensions.push(
+				extension_1, extension_2, extension_3, extension_4
+			);
 		}
 	}
 

--- a/extension/schemas/org.gnome.shell.extensions.gestureImprovements.gschema.xml
+++ b/extension/schemas/org.gnome.shell.extensions.gestureImprovements.gschema.xml
@@ -1,5 +1,17 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <schemalist>
+  <enum id='org.gnome.shell.extensions.gestureImprovements.horizontal-swipe-gestures'>
+    <value value='0' nick='WINDOW_SWITCHING' />
+    <value value='1' nick='APP_NAVIGATION' />
+    <value value='2' nick='WORKSPACE_SWITCHING' />
+  </enum>
+
+  <enum id='org.gnome.shell.extensions.gestureImprovements.vertical-swipe-gestures'>
+    <value value='0' nick='OVERVIEW_NAVIGATION'>
+    <value value='1' nick='APP_NAVIGATION' />
+    <value value='2' nick='WINDOW_MANIPULATION' />
+  </enum>
+
   <enum id='org.gnome.shell.extensions.gestureImprovements.pinch-gestures'>
     <value value='0' nick='NONE' />
     <value value='1' nick='SHOW_DESKTOP' />
@@ -12,6 +24,7 @@
     <value value='1' nick='GNOME' />
     <value value='2' nick='WINDOW_PICKER_ONLY' />
   </enum>
+  
   <schema id="org.gnome.shell.extensions.gestureImprovements" path="/org/gnome/shell/extensions/gestureImprovements/">
     <!-- See also: https://docs.gtk.org/glib/gvariant-format-strings.html -->
     <key name="touchpad-speed-scale" type="d">
@@ -26,18 +39,36 @@
     <key name="hold-swipe-delay-duration" type="i">
       <default>100</default>
     </key>
-    <key name='default-session-workspace' type='b'>
-      <default>false</default>
-      <description>If true, use 3-fingers to switch workspace, 4 for windows</description>
+
+    <!-- 3 finger gestures -->
+    <key name="swipe-horizontal-3-finger-gesture" enum="org.gnome.shell.extensions.gestureImprovements.horizontal-swipe-gestures">
+      <default>'WINDOW_SWITCHING'</default>
+      <description>Gesture for 3 finger Left/Right Swipe</description>
     </key>
-    <key name='default-overview' type='b'>
-      <default>false</default>
-      <description>If true, use 3-fingers for overview gesture, 4 for snapping/tiling</description>
+    <key name="swipe-vertical-3-finger-gesture" enum="org.gnome.shell.extensions.gestureImprovements.vertical-swipe-gestures">
+      <default>'OVERVIEW_NAVIGATION'</default>
+      <description>Gesture for 3 finger Top/Down Swipe</description>
     </key>
-    <key name='allow-minimize-window' type='b'>
-      <default>false</default>
-      <description>If true, when swipe down on non-maximized window minimizes it</description>
+    <key name="pinch-3-finger-gesture" enum="org.gnome.shell.extensions.gestureImprovements.pinch-gestures">
+      <default>'NONE'</default>
+      <description>Gesture for 3 finger pinch</description>
     </key>
+
+    <!-- 4 finger gestures -->
+    <key name="swipe-horizontal-4-finger-gesture" enum="org.gnome.shell.extensions.gestureImprovements.horizontal-swipe-gestures">
+      <default>'WORKSPACE_SWITCHING'</default>
+      <description>Gesture for 4 finger Left/Right Swipe</description>
+    </key>
+    <key name="swipe-vertical-4-finger-gesture" enum="org.gnome.shell.extensions.gestureImprovements.vertical-swipe-gestures">
+      <default>'APP_NAVIGATION'</default>
+      <description>Gesture for 4 finger Top/Down Swipe</description>
+    </key>
+    <key name="pinch-4-finger-gesture" enum="org.gnome.shell.extensions.gestureImprovements.pinch-gestures">
+      <default>'SHOW_DESKTOP'</default>
+      <description>Gesture for 4 finger pinch</description>
+    </key>
+
+
     <key name='follow-natural-scroll' type='b'>
       <default>true</default>
       <description>Whether to follow natural scroll for swipe</description>
@@ -51,20 +82,8 @@
       <description>Enable alttab gesture</description>
     </key>
     <key name='enable-forward-back-gesture' type='b'>
-      <default>false</default>
-      <description>Enable forward/back keybinding gesture</description>
-    </key>
-    <key name='enable-window-manipulation-gesture' type='b'>
       <default>true</default>
-      <description>Enable Window manipulation gesture</description>
-    </key>
-    <key name="pinch-3-finger-gesture" enum="org.gnome.shell.extensions.gestureImprovements.pinch-gestures">
-      <default>'NONE'</default>
-      <description>Gesture for 3 finger pinch</description>
-    </key>
-    <key name="pinch-4-finger-gesture" enum="org.gnome.shell.extensions.gestureImprovements.pinch-gestures">
-      <default>'SHOW_DESKTOP'</default>
-      <description>Gesture for 4 finger pinch</description>
+      <description>Enable forward/back keybinding gesture</description>
     </key>
     <key name="overview-navifation-states" enum="org.gnome.shell.extensions.gestureImprovements.overview-navigation-states">
       <default>'CYCLIC'</default>

--- a/extension/src/forwardBack.ts
+++ b/extension/src/forwardBack.ts
@@ -48,10 +48,10 @@ export class ForwardBackGestureExtension implements ISubExtension {
 
 		this._swipeTracker = createSwipeTracker(
 			global.stage,
-			ExtSettings.DEFAULT_SESSION_WORKSPACE_GESTURE ? [4] : [3],
+			ExtSettings.DEFAULT_OVERVIEW_GESTURE ? [4] : [3],
 			Shell.ActionMode.NORMAL,
-			Clutter.Orientation.HORIZONTAL,
-			false,
+			ExtSettings.DEFAULT_OVERVIEW_GESTURE ? Clutter.Orientation.VERTICAL : Clutter.Orientation.HORIZONTAL,
+			ExtSettings.DEFAULT_OVERVIEW_GESTURE ? true : false,
 			1,
 			{ allowTouch: false },
 		);

--- a/extension/src/gestures.ts
+++ b/extension/src/gestures.ts
@@ -3,7 +3,13 @@ import GObject from '@gi-types/gobject2';
 import Shell from '@gi-types/shell';
 import { CustomEventType, global, imports, __shell_private_types } from 'gnome-shell';
 import { ExtSettings, OverviewControlsState } from '../constants';
-import { createSwipeTracker, TouchpadSwipeGesture } from './swipeTracker';
+import { createSwipeTracker, TouchpadSwipeGesture } from './trackers/swipeTracker';
+
+import { SnapWindowExtension } from '../src/swipeGestures/snapWindow';
+import { AltTabGestureExtension } from '../src/swipeGestures/altTab';
+import { ForwardBackGestureExtension } from '../src/swipeGestures/forwardBack';
+import { OverviewRoundTripGestureExtension } from '../src/swipeGestures/overviewRoundTrip';
+import { GioSettings } from '../common/settings';
 
 const Main = imports.ui.main;
 
@@ -79,12 +85,13 @@ class WorkspaceAnimationModifier extends SwipeTrackerEndPointsModifer {
 	private _workspaceAnimation: imports.ui.workspaceAnimation.WorkspaceAnimationController;
 	protected _swipeTracker: SwipeTrackerT;
 
-	constructor(wm: typeof imports.ui.main.wm) {
+	constructor(wm: typeof imports.ui.main.wm, n_fingers: number[]) {
 		super();
 		this._workspaceAnimation = wm._workspaceAnimation;
 		this._swipeTracker = createSwipeTracker(
 			global.stage,
-			(ExtSettings.DEFAULT_SESSION_WORKSPACE_GESTURE ? [3] : [4]),
+			// (ExtSettings.DEFAULT_SESSION_WORKSPACE_GESTURE ? [3] : [4]),
+			n_fingers, 
 			Shell.ActionMode.NORMAL,
 			Clutter.Orientation.HORIZONTAL,
 			ExtSettings.FOLLOW_NATURAL_SCROLL,
@@ -138,7 +145,7 @@ export class GestureExtension implements ISubExtension {
 	private _swipeTrackers: ShellSwipeTracker[];
 	private _workspaceAnimationModifier: WorkspaceAnimationModifier;
 
-	constructor() {
+	constructor(n_fingers: number[]) {
 		this._stateAdjustment = Main.overview._overview._controls._stateAdjustment;
 		this._swipeTrackers = [
 			{
@@ -174,7 +181,7 @@ export class GestureExtension implements ISubExtension {
 			},
 		];
 
-		this._workspaceAnimationModifier = new WorkspaceAnimationModifier(Main.wm);
+		this._workspaceAnimationModifier = new WorkspaceAnimationModifier(Main.wm, n_fingers);
 	}
 
 	apply(): void {
@@ -238,5 +245,97 @@ export class GestureExtension implements ISubExtension {
 			'orientation',
 			GObject.BindingFlags.SYNC_CREATE,
 		);
+	}
+}
+
+export class SwipeGestureInfo {
+	orientation: Clutter.Orientation;
+	n_fingers: number[];
+	enum_id: number; 
+
+	constructor(orientation: Clutter.Orientation, 
+				n_fingers: number[],
+				enum_id: number) {
+		this.orientation = orientation;
+		this.n_fingers = n_fingers;
+		this.enum_id = enum_id;
+	}
+}
+
+export class SwipeGestureToExtensionMapper {
+	private settings: GioSettings;
+	private extensionInUse = {
+		"WINDOW_SWITCHING": false,
+		"APP_NAVIGATION": false,
+		"WORKSPACE_SWITCHING": false,
+		"OVERVIEW_NAVIGATION": false,
+		"WINDOW_MANIPULATION": false
+	};
+
+	constructor(settings: GioSettings) {
+		this.settings = settings;
+	}
+
+	get_extension(gesture: SwipeGestureInfo) {
+		if (gesture.orientation === Clutter.Orientation.HORIZONTAL) {
+			switch (gesture.enum_id) {
+				case 0: {
+					if (this.extensionInUse["WORKSPACE_SWITCHING"] === false) {
+						this.extensionInUse["WORKSPACE_SWITCHING"] = true;
+						return new AltTabGestureExtension(gesture.n_fingers);
+					}
+				}
+				case 1: {
+					if (this.settings.get_boolean('enable-forward-back-gesture') &&
+						this.extensionInUse["APP_NAVIGATION"] === false) {
+						this.extensionInUse["APP_NAVIGATION"] = true
+						const appForwardBackKeyBinds = this.settings.get_value('forward-back-application-keyboard-shortcuts').deepUnpack();
+						return new ForwardBackGestureExtension(
+							appForwardBackKeyBinds,
+							gesture.n_fingers,
+							gesture.orientation,
+							false
+						);
+					}
+				}
+				case 2: {
+					if (this.extensionInUse["WORKSPACE_SWITCHING"] === false) {
+						this.extensionInUse["WORKSPACE_SWITCHING"] = true;
+						return new GestureExtension(gesture.n_fingers);
+					}
+				}
+			} 
+		} else if (gesture.orientation == Clutter.Orientation.VERTICAL) {
+			switch (gesture.enum_id) {
+				case 0: {
+					if (this.extensionInUse["OVERVIEW_NAVIGATION"] === false) {
+						this.extensionInUse["OVERVIEW_NAVIGATION"] = true
+						return new OverviewRoundTripGestureExtension(
+							this.settings.get_enum('overview-navigation-states'),
+							gesture.n_fingers
+						);
+					}
+				}
+				case 1: {
+					if (this.settings.get_boolean('enable-forward-back-gesture') &&
+						this.extensionInUse["APP_NAVIGATION"] === false) {
+						this.extensionInUse["APP_NAVIGATION"] = true
+						const appForwardBackKeyBinds = this.settings.get_value('forward-back-application-keyboard-shortcuts').deepUnpack();
+						return new ForwardBackGestureExtension(
+							appForwardBackKeyBinds,
+							gesture.n_fingers,
+							gesture.orientation,
+							true
+						);
+					}
+				}
+				case 2: {
+					if (this.extensionInUse["WINDOW_MANIPULATION"] == false){
+						this.extensionInUse["WINDOW_MANIPULATION"] = true;
+						return new SnapWindowExtension(gesture.n_fingers);
+					}
+				}
+			}
+		}
 	}
 }

--- a/extension/src/swipeGestures/altTab.ts
+++ b/extension/src/swipeGestures/altTab.ts
@@ -3,8 +3,8 @@ import GLib from '@gi-types/glib2';
 import Shell from '@gi-types/shell';
 import St from '@gi-types/st';
 import { imports } from 'gnome-shell';
-import { AltTabConstants, ExtSettings } from '../constants';
-import { TouchpadSwipeGesture } from './swipeTracker';
+import { AltTabConstants, ExtSettings } from '../../constants';
+import { TouchpadSwipeGesture } from '../trackers/swipeTracker';
 
 const Main = imports.ui.main;
 const { WindowSwitcherPopup } = imports.ui.altTab;
@@ -41,11 +41,12 @@ export class AltTabGestureExtension implements ISubExtension {
 	private _progress = 0;
 	private _altTabTimeoutId = 0;
 
-	constructor() {
+	constructor(n_fingers: number[]) {
 		this._connectHandlers = [];
 
 		this._touchpadSwipeTracker = new TouchpadSwipeGesture(
-			(ExtSettings.DEFAULT_SESSION_WORKSPACE_GESTURE ? [4] : [3]),
+			// (ExtSettings.DEFAULT_SESSION_WORKSPACE_GESTURE ? [4] : [3]),
+			n_fingers,
 			Shell.ActionMode.ALL,
 			Clutter.Orientation.HORIZONTAL,
 			false,

--- a/extension/src/swipeGestures/forwardBack.ts
+++ b/extension/src/swipeGestures/forwardBack.ts
@@ -4,11 +4,11 @@ import Meta from '@gi-types/meta';
 
 import { imports, global } from 'gnome-shell';
 
-import { ExtSettings } from '../constants';
-import { ArrowIconAnimation } from './animations/arrow';
-import { createSwipeTracker } from './swipeTracker';
-import { getVirtualKeyboard, IVirtualKeyboard } from './utils/keyboard';
-import { ForwardBackKeyBinds } from '../common/settings';
+import { ExtSettings } from '../../constants';
+import { ArrowIconAnimation } from '../animations/arrow';
+import { createSwipeTracker } from '../trackers/swipeTracker';
+import { getVirtualKeyboard, IVirtualKeyboard } from '../utils/keyboard';
+import { ForwardBackKeyBinds } from '../../common/settings';
 
 const Main = imports.ui.main;
 declare type SwipeTrackerT = imports.ui.swipeTracker.SwipeTracker;
@@ -41,20 +41,34 @@ export class ForwardBackGestureExtension implements ISubExtension {
 	private _windowTracker: Shell.WindowTracker;
 	private _focusWindow?: Meta.Window | null;
 
-	constructor(appForwardBackKeyBinds: AppForwardBackKeyBinds) {
+	constructor(appForwardBackKeyBinds: AppForwardBackKeyBinds,
+				n_fingers: number[], 
+				orientation: Clutter.Orientation,
+				natural_scroll_direction: boolean) {
 		this._appForwardBackKeyBinds = appForwardBackKeyBinds;
 		this._windowTracker = Shell.WindowTracker.get_default();
 		this._keyboard = getVirtualKeyboard();
 
+		// TODO: fix it with settings
+		// this._swipeTracker = createSwipeTracker(
+		// 	global.stage,
+		// 	ExtSettings.DEFAULT_OVERVIEW_GESTURE ? [4] : [3],     // n fingers
+		// 	Shell.ActionMode.NORMAL,				
+		// 	ExtSettings.DEFAULT_OVERVIEW_GESTURE ? Clutter.Orientation.VERTICAL : Clutter.Orientation.HORIZONTAL,	// direction
+		// 	ExtSettings.DEFAULT_OVERVIEW_GESTURE ? true : false,  // Natural scroll direction (scroll down in moving up)
+		// 	1,
+		// 	{ allowTouch: false },
+		// );
 		this._swipeTracker = createSwipeTracker(
 			global.stage,
-			ExtSettings.DEFAULT_OVERVIEW_GESTURE ? [4] : [3],
-			Shell.ActionMode.NORMAL,
-			ExtSettings.DEFAULT_OVERVIEW_GESTURE ? Clutter.Orientation.VERTICAL : Clutter.Orientation.HORIZONTAL,
-			ExtSettings.DEFAULT_OVERVIEW_GESTURE ? true : false,
+			n_fingers,     // n fingers
+			Shell.ActionMode.NORMAL,				
+			orientation,	// direction
+			natural_scroll_direction,  // Natural scroll direction (scroll down in moving up)
 			1,
 			{ allowTouch: false },
 		);
+
 
 		this._connectHandlers = [
 			this._swipeTracker.connect('begin', this._gestureBegin.bind(this)),

--- a/extension/src/swipeGestures/overviewRoundTrip.ts
+++ b/extension/src/swipeGestures/overviewRoundTrip.ts
@@ -1,9 +1,9 @@
 import Clutter from '@gi-types/clutter';
 import Shell from '@gi-types/shell';
 import { global, imports } from 'gnome-shell';
-import { OverviewNavigationState } from '../common/settings';
-import { ExtSettings, OverviewControlsState } from '../constants';
-import { createSwipeTracker } from './swipeTracker';
+import { OverviewNavigationState } from '../../common/settings';
+import { ExtSettings, OverviewControlsState } from '../../constants';
+import { createSwipeTracker } from '../trackers/swipeTracker';
 
 const Main = imports.ui.main;
 const { SwipeTracker } = imports.ui.swipeTracker;
@@ -26,9 +26,12 @@ export class OverviewRoundTripGestureExtension implements ISubExtension {
 	private _shownEventId = 0;
 	private _hiddenEventId = 0;
 	private _navigationStates: OverviewNavigationState;
+	private n_fingers: number[]
 
-	constructor(navigationStates: OverviewNavigationState) {
+	constructor(navigationStates: OverviewNavigationState, 
+				n_fingers: number[]) {
 		this._navigationStates = navigationStates;
+		this.n_fingers = n_fingers;
 		this._overviewControls = Main.overview._overview._controls;
 		this._stateAdjustment = this._overviewControls._stateAdjustment;
 		this._oldGetStateTransitionParams = this._overviewControls._stateAdjustment.getStateTransitionParams;
@@ -63,7 +66,8 @@ export class OverviewRoundTripGestureExtension implements ISubExtension {
 
 		this._swipeTracker = createSwipeTracker(
 			global.stage,
-			(ExtSettings.DEFAULT_OVERVIEW_GESTURE ? [3] : [4]),
+			// (ExtSettings.DEFAULT_OVERVIEW_GESTURE ? [3] : [4]), 
+			this.n_fingers, 
 			Shell.ActionMode.NORMAL | Shell.ActionMode.OVERVIEW,
 			Clutter.Orientation.VERTICAL,
 			ExtSettings.DEFAULT_OVERVIEW_GESTURE_DIRECTION,

--- a/extension/src/swipeGestures/snapWindow.ts
+++ b/extension/src/swipeGestures/snapWindow.ts
@@ -3,11 +3,11 @@ import Meta from '@gi-types/meta';
 import Shell from '@gi-types/shell';
 import St from '@gi-types/st';
 import { global, imports } from 'gnome-shell';
-import { registerClass } from '../common/utils/gobject';
-import { ExtSettings } from '../constants';
-import { createSwipeTracker, TouchpadSwipeGesture } from './swipeTracker';
-import { easeActor, easeAdjustment } from './utils/environment';
-import { getVirtualKeyboard, IVirtualKeyboard } from './utils/keyboard';
+import { registerClass } from '../../common/utils/gobject';
+import { ExtSettings } from '../../constants';
+import { createSwipeTracker, TouchpadSwipeGesture } from '../trackers/swipeTracker';
+import { easeActor, easeAdjustment } from '../utils/environment';
+import { getVirtualKeyboard, IVirtualKeyboard } from '../utils/keyboard';
 
 
 const Main = imports.ui.main;
@@ -281,10 +281,11 @@ export class SnapWindowExtension implements ISubExtension {
 	private _allowChangeDirection = false;
 	private _uiGroupAddedActorId: number;
 
-	constructor() {
+	constructor(n_fingers: number[]) {
 		this._swipeTracker = createSwipeTracker(
 			global.stage,
-			(ExtSettings.DEFAULT_OVERVIEW_GESTURE ? [4] : [3]),
+			// (ExtSettings.DEFAULT_OVERVIEW_GESTURE ? [4] : [3]),
+			n_fingers,
 			Shell.ActionMode.NORMAL,
 			Clutter.Orientation.VERTICAL,
 			true,

--- a/extension/src/trackers/swipeTracker.ts
+++ b/extension/src/trackers/swipeTracker.ts
@@ -3,9 +3,9 @@ import GObject from '@gi-types/gobject2';
 import Meta from '@gi-types/meta';
 import Shell from '@gi-types/shell';
 import { CustomEventType, global, imports } from 'gnome-shell';
-import { registerClass } from '../common/utils/gobject';
-import { TouchpadConstants } from '../constants';
-import * as DBusUtils from './utils/dbus';
+import { registerClass } from '../../common/utils/gobject';
+import { TouchpadConstants } from '../../constants';
+import * as DBusUtils from '../utils/dbus';
 
 const Main = imports.ui.main;
 const { SwipeTracker } = imports.ui.swipeTracker;

--- a/extension/ui/gestures.ui
+++ b/extension/ui/gestures.ui
@@ -3,6 +3,22 @@
   <requires lib="gtk" version="4.0" />
   <requires lib="libadwaita" version="1.0" />
 
+  <object class="GtkStringList" id="horizontal_swipe_gestures_model">
+    <items>
+      <item translatable="yes">Window Switching</item>
+      <item translatable="yes">App Navigation</item>
+      <item translatable="yes">Workspace Switching</item>
+    </items>
+  </object>
+
+  <object class="GtkStringList" id="vertical_swipe_gestures_model">
+    <items>
+      <item translatable="yes">Overview Navigation</item>
+      <item translatable="yes">App Navigation</item>
+      <item translatable="yes">Window Manipulation</item>
+    </items>
+  </object>
+
   <object class="GtkStringList" id="pinch_gestures_model">
     <items>
       <item translatable="yes">None</item>
@@ -12,92 +28,32 @@
     </items>
   </object>
 
+
   <object class="AdwPreferencesPage" id="gestures_page">
     <property name="title">Gestures</property>
     <property name="icon-name">gesture-swipe-right-symbolic</property>
 
-    <!-- Swipe Gestures -->
+    <!-- New UI -->
+    <!-- 3 Finger Gestures -->
     <child>
       <object class="AdwPreferencesGroup">
-        <property name="title">Swipe Gestures</property>
+        <property name="title">3 Finger Gestures</property>
 
-        <!-- Use default(4-finger) for session overview navigation -->
+        <!-- 3 finger horizontal gesture -->
         <child>
-          <object class="AdwActionRow">
-            <property name="title" translatable="yes">4-finger gestures for overview navigation</property>
-            <property name="subtitle">For navigating between desktop, activities and appgrid</property>
-            <child>
-              <object class="GtkSwitch" id="default-overview">
-                <property name="valign">center</property>
-                <property name="active">True</property>
-              </object>
-            </child>
+          <object class="AdwComboRow" id="swipe-horizontal-3-finger-gesture">
+            <property name="title" translatable="yes">3 finger Left/Right Swipe</property>
+            <property name="model">horizontal_swipe_gestures_model</property>
           </object>
         </child>
 
-        <!-- Use default(4-finger) for session workspace switching -->
+        <!-- 3 finger vertical gesture -->
         <child>
-          <object class="AdwActionRow">
-            <property name="title" translatable="yes">4-finger gestures for workspace switching</property>
-            <child>
-              <object class="GtkSwitch" id="default-session-workspace">
-                <property name="valign">center</property>
-                <property name="active">True</property>
-              </object>
-            </child>
+          <object class="AdwComboRow" id="swipe-vertical-3-finger-gesture">
+            <property name="title" translatable="yes">3 finger Up/Down Swipe</property>
+            <property name="model">vertical_swipe_gestures_model</property>
           </object>
         </child>
-
-        <!-- AltTab Gesture -->
-        <child>
-          <object class="AdwActionRow">
-            <property name="title" translatable="yes">Window switching</property>
-            <child>
-              <object class="GtkSwitch" id="enable-alttab-gesture">
-                <property name="valign">center</property>
-                <property name="active">True</property>
-              </object>
-            </child>
-          </object>
-        </child>
-        
-        <!-- Window manipulation Gesture -->
-        <child>
-          <object class="AdwActionRow">
-            <property name="title" translatable="yes">Window manipulation</property>
-            <property name="subtitle">Tile, unmaximize, maximize or fullscreen a window</property>
-            <child>
-              <object class="GtkSwitch" id="enable-window-manipulation-gesture">
-                <property name="valign">center</property>
-                <property name="active">True</property>
-              </object>
-            </child>
-          </object>
-        </child>
-
-        <!-- Minimize window -->
-        <child>
-          <object class="AdwActionRow">
-            <property name="title" translatable="yes">Minimize window</property>
-            <property name="subtitle">This will disable tiling gesture</property>
-            <property name="sensitive" bind-source="enable-window-manipulation-gesture" bind-property="active" bind-flags="sync-create"></property>
-            <child>
-              <object class="GtkSwitch" id="allow-minimize-window">
-                <property name="valign">center</property>
-                <property name="active">True</property>
-              </object>
-            </child>
-          </object>
-        </child>
-
-      </object>
-
-    </child>
-
-    <!-- Pinch Gestures -->
-    <child>
-      <object class="AdwPreferencesGroup">
-        <property name="title">Pinch Gestures</property>
 
         <!-- 3 finger pinch gesture -->
         <child>
@@ -107,15 +63,42 @@
           </object>
         </child>
 
-        <!-- 4 finger pinch gesture -->
+        <!-- TODO: 3 finger Tap gesture-->
+      </object>
+    </child>
+
+    <!-- 4 Finger Gestures -->
+    <child>
+      <object class="AdwPreferencesGroup">
+        <property name="title">4 Finger Gestures</property>
+
+        <!-- 4 finger horizontal gesture -->
+        <child>
+          <object class="AdwComboRow" id="swipe-horizontal-4-finger-gesture">
+            <property name="title" translatable="yes">4 finger Left/Right Swipe</property>
+            <property name="model">horizontal_swipe_gestures_model</property>
+          </object>
+        </child>
+
+        <!-- 3 finger vertical gesture -->
+        <child>
+          <object class="AdwComboRow" id="swipe-vertical-4-finger-gesture">
+            <property name="title" translatable="yes">4 finger Up/Down Swipe</property>
+            <property name="model">vertical_swipe_gestures_model</property>
+          </object>
+        </child>
+
+        <!-- 3 finger pinch gesture -->
         <child>
           <object class="AdwComboRow" id="pinch-4-finger-gesture">
             <property name="title" translatable="yes">4 finger pinch</property>
             <property name="model">pinch_gestures_model</property>
           </object>
         </child>
-      </object>
 
+        <!-- TODO: 4 finger Tap gesture-->
+      </object>
     </child>
+
   </object>
 </interface>

--- a/metadata.json
+++ b/metadata.json
@@ -7,5 +7,5 @@
 	"settings-schema": "org.gnome.shell.extensions.gestureImprovements",
 	"url": "https://github.com/harshadgavali/gnome-gesture-improvements",
 	"uuid": "gestureImprovements@gestures",
-	"version": 22.5
+	"version": 23
 }


### PR DESCRIPTION
Hey @harshadgavali, 
This is a draft PR and requires your help (and possible review). Follow up from PR #98. 

Currently, the changes I have made require the user to select Extension (functionality) the user intends to use. So something like (visualize in your mind) or check [ui file for gestures](https://github.com/adhadse/gnome-gesture-improvements/blob/drop_down/extension/ui/gestures.ui):
**Swipe Gestures**:
**Three Finger gestures**:
- 3 finger Left/Right Swipe : dropdown menu
- 3 finger Top/Down Swipe: dropdown menu
- Pinch: dropdown menu

**Four Finger gestures**:
- 4 finger Left/Right Swipe : dropdown menu
- 4 finger Top/Down Swipe: dropdown menu
- Pinch: dropdown menu

Apart from that I also moved swipe gestures src code files into their dedicated folder resonating with pinch gesture and tracker files.

Main Modification are done to [`extension.ts`](https://github.com/adhadse/gnome-gesture-improvements/blob/drop_down/extension/extension.ts#L123-L160) creating a new function that set the sub-extension and gesture using a new Class [`SwipeGestureToExtensionMapper`](https://github.com/adhadse/gnome-gesture-improvements/blob/drop_down/extension/src/gestures.ts#L251-L341) given the gesture info (n_fingers, horizontal/vertical & natural scroll in case of app navigation). This class makes sure that two gestures don't get mapped to the same extension.

The problem is, here on this [line](https://github.com/adhadse/gnome-gesture-improvements/blob/drop_down/extension/src/gestures.ts#L251-L341) the extension can be `undefined` which we can't push to `_extensions`. So that means `if` condition in [`get_extension`](https://github.com/adhadse/gnome-gesture-improvements/blob/drop_down/extension/src/gestures.ts#L279) function's switch condition, **we need to generate error and throw Dialog box informing user two gestures can't be set for one functionality** OR If you have some better idea.


